### PR TITLE
Add support to new goth versions

### DIFF
--- a/lib/waffle/storage/google/util.ex
+++ b/lib/waffle/storage/google/util.ex
@@ -3,12 +3,6 @@ defmodule Waffle.Storage.Google.Util do
   A collection of utility functions.
   """
 
-  alias GoogleApi.Gax.{Request, Response}
-  alias GoogleApi.Storage.V1.Connection
-  alias GoogleApi.Storage.V1.Model.Object
-
-  @library_version Mix.Project.config() |> Keyword.get(:version, "")
-
   @doc """
   Accepts four forms of variables:
 

--- a/mix.exs
+++ b/mix.exs
@@ -39,6 +39,7 @@ defmodule Waffle.Storage.Google.CloudStorage.MixProject do
     [
       {:waffle, "~> 1.1"},
       {:goth, "~> 1.1"},
+      {:gcs_signed_url, "~> 0.4"},
       {:google_api_storage, "~> 0.14"},
       {:ex_doc, ">= 0.0.0", only: :dev, runtime: false},
     ]


### PR DESCRIPTION
Add support for new goth versions.

A couple of functions need to be added to the Waffle.Definition module:

```elixir
  # Specify the Goth module to authenticate in GCP.
  def goth_module do
    MyApp.Goth.Storage
  end

  # Defines the service account file to be used to sign the urls.
  def service_account_path do
    Application.fetch_env!(:my_app, :gcp_storage)
    |> Keyword.get(:service_account_path)
  end
```